### PR TITLE
Python 3.7 sürümü ile sözlüklere gelen güncelleme

### DIFF
--- a/_sources/sozluklerin_metotlari.rst.txt
+++ b/_sources/sozluklerin_metotlari.rst.txt
@@ -445,18 +445,15 @@ popitem()
 ``popitem()`` metodu da bir önceki bölümde öğrendiğimiz ``pop()`` metoduna
 benzer. Bu iki metodun görevleri hemen hemen aynıdır. Ancak ``pop()`` metodu
 parantez içinde bir parametre alırken, ``popitem()`` metodunun parantezi boş,
-yani parametresiz olarak kullanılır. Bu metot bir sözlükten rastgele öğeler
-silmek için kullanılır. Daha önce de pek çok kez söylediğimiz gibi, sözlükler
-sırasız veri tipleridir. Dolayısıyla ``popitem()`` metodunun öğeleri silerken
-kullanabileceği bir sıra kavramı yoktur. Bu yüzden bu metot öğeleri rastgele
-silmeyi tercih eder... ::
+yani parametresiz olarak kullanılır. Bu metot sözlükten son eklenen öğeyi
+silmek için kullanılır(Python 3.7'den önceki sürümlerde bunun yerine rastgele 
+bir öğe kaldırılır). ::
 
 	>>> sepet = {"meyveler": ("elma", "armut"), "sebzeler": ("pırasa", "fasulye")}
 
 	>>> sepet.popitem()
 
-Bu komut sözlükten rastgele bir anahtarı, değerleriyle birlikte sözlükten
-silecektir. Eğer sözlük boşsa bu metot bize bir hata mesajı gösterir.
+Eğer sözlük boşsa bu metot bize KeyError hata mesajı gösterir.
 
 setdefault()
 *************


### PR DESCRIPTION
Changed in version 3.7: LIFO order is now guaranteed. In prior versions, popitem() would return an arbitrary key/value pair.