### PR TITLE
Update donguler.rst

### DIFF
--- a/source/donguler.rst
+++ b/source/donguler.rst
@@ -1281,8 +1281,8 @@ continue Deyimi
 
         if len(s) <= 3:
             continue
-
-        print("En fazla üç haneli bir sayı girebilirsiniz.")
+        else:
+            print("En fazla üç haneli bir sayı girebilirsiniz.")
 
 Burada eğer kullanıcı klavyede `iptal` yazarsa programdan çıkılacaktır. Bunu; ::
 


### PR DESCRIPTION
Merhaba, 14.3.4'te (sayfa 222) continue deyimini öğrenmeye çalışırken kodu çalıştırdım fakat 4 haneden fazla karakter girmeme rağmen "En fazla üç haneli bir sayı girebilirsiniz." uyarısını almadım. Bunun üzerine bildiğim kadarıyla kodu düzeltmeye çalıştım ve yaptığım değişiklikten sonra uyarıyı almayı başardım. önceki hali:

while True:

    s = input("Bir sayı girin: ")

    if s == "iptal":
        break

    if len(s) <= 3:
        continue   

    print("En fazla üç haneli bir sayı girebilirsiniz.")

 şeklindeydi. Ben de "continue" deyiminden sonra "else" deyimini ekledim ve sorunun düzeldiğini fark ettim. Şöyle değiştirdim:

while True:

    s = input("Bir sayı girin: ")
    
    if s == "iptal":
        break
        
    if len(s) <= 3:
        continue
        
    else:
        print("En fazla üç haneli bir sayı girebilirsiniz.")