### PR TITLE
Hata giderilmesi

### DIFF
--- a/source/donguler.rst
+++ b/source/donguler.rst
@@ -1819,8 +1819,8 @@ nasıl yapılacağını az çok tahmin ettiğinizi zannediyorum::
     d1.close()
     d2.close()
 
-Burada bir öncekinden farklı olarak ``if not i in d2_satırlar`` kodu yerine,
-doğal olarak, ``if i in d2_satırlar`` kodunu kullandığımıza dikkat edin.
+Burada bir öncekinden farklı olarak ``if not i in d1_satırlar`` kodu yerine,
+doğal olarak, ``if i in d1_satırlar`` kodunu kullandığımıza dikkat edin.
 
 Dosyalar üzerinde yaptığımız işlemleri tamamladıktan sonra ``close()`` metodu
 ile bunları kapatmayı unutmuyoruz::
@@ -2075,8 +2075,3 @@ Son olarak da, ilk başta açtığımız dosyayı kapatıyoruz::
 Nihayet bir konunun daha sonuna ulaştık. Döngüler ve döngülerle ilişkili
 araçları da epey ayrıntılı bir şekilde incelediğimize göre gönül rahatlığıyla
 bir sonraki konuya geçebiliriz.
-
-
-
-
-

--- a/source/katkida_bulunanlar.rst
+++ b/source/katkida_bulunanlar.rst
@@ -526,3 +526,7 @@ Beyazıt Uysal
     - '/Ucuncu_taraf_moduller/kivy_dersleri/widgets.rst'  dosyası altında bulunan bir kod bloğunda iki kez kütüphane importu giderildi.
     - islecler.rst dosyası içerisinde bulunan "görüntülecektir" kelimesi "görüntülenecektir" olarak düzeltildi.
     - kurulum.rst dosyası içerisinde bulunan "yazağımız" kelimesi "yazacağımız" olarak düzeltildi.
+    - donguler.rst altinda yer alan "Dosyaların İçeriğini Karşılaştırma basliginda" kod açıkklama hatası düzeltildi.
+    - sozlukler.rst dosyasında yer alan ve sözlüklerin sıraya sahip olması ile ilgili olan not, html dosyasında hatalı bir gorunume sahipti bu hata giderildi.
+
+

--- a/source/katkida_bulunanlar.rst
+++ b/source/katkida_bulunanlar.rst
@@ -526,7 +526,5 @@ Beyazıt Uysal
     - '/Ucuncu_taraf_moduller/kivy_dersleri/widgets.rst'  dosyası altında bulunan bir kod bloğunda iki kez kütüphane importu giderildi.
     - islecler.rst dosyası içerisinde bulunan "görüntülecektir" kelimesi "görüntülenecektir" olarak düzeltildi.
     - kurulum.rst dosyası içerisinde bulunan "yazağımız" kelimesi "yazacağımız" olarak düzeltildi.
-    - donguler.rst altinda yer alan "Dosyaların İçeriğini Karşılaştırma basliginda" kod açıkklama hatası düzeltildi.
-    - sozlukler.rst dosyasında yer alan ve sözlüklerin sıraya sahip olması ile ilgili olan not, html dosyasında hatalı bir gorunume sahipti bu hata giderildi.
-
-
+    - donguler.rst altında yer alan 'Dosyaların İçeriğini Karşılaştırma' başlığında kod açıklama hatası düzeltildi.
+    - sozlukler.rst dosyasında yer alan ve sözlüklerin sıraya sahip olmasıyla ilgili not, HTML dosyasında hatalı bir görünüme sahipti, ancak bu sorun giderildi.

--- a/source/sozlukler.rst
+++ b/source/sozlukler.rst
@@ -496,9 +496,7 @@ Sözlüklerin öteki veri tiplerinden önemli bir farkı, sözlük içinde yer
 alan öğelerin herhangi bir sıralama mantığına sahip olmamasıdır. Yani sözlükteki
 öğeler açısından 'sıra' diye bir kavram yoktur.
 
-.. note:: Python3.7'dan başlayarak sözlükler içerdikleri öğelerin eklenme sırasını korumaktadır. Python'un 3.7'den yüksek bir versiyonunda
-    oluşturduğunuz sözlükleri ekrana yazdırmayı denerseniz sözlüğü oluştururken elemanların içinde bulunduğu sıranın korunduğunu siz de görebilirsiniz.
-    Ancak sözlüklerin elemanlarına listeler gibi bir sıra ile (``liste[sıra]`` gibi) erişelemez. Ayrıntılı bilgi için `buraya <https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6>`_ bakabilirsiniz.
+.. note:: Python3.7'dan başlayarak sözlükler içerdikleri öğelerin eklenme sırasını korumaktadır. Python'un 3.7'den yüksek bir versiyonunda oluşturduğunuz sözlükleri ekrana yazdırmayı denerseniz sözlüğü oluştururken elemanların içinde bulunduğu sıranın korunduğunu siz de görebilirsiniz. Ancak sözlüklerin elemanlarına listeler gibi bir sıra ile (``liste[sıra]`` gibi) erişelemez. Ayrıntılı bilgi için `buraya <https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6>`_ bakabilirsiniz.
 
 Örneğin bir liste, demet veya karakter dizisi içindeki öğelere; bu öğelerin o
 liste, demet veya karakter dizisi içindeki sıralarına göre erişebilirsiniz::
@@ -846,10 +844,3 @@ Bildiğiniz gibi sözlükler, her biri birbirinden `:` işareti ile ayrılan bir
 anahtar-değer çiftlerinden oluşuyor. İşte yukarıdaki sözlük üreteci yapısında
 biz `:` işaretinin sol tarafına `isimler` adlı listedeki her bir öğeyi; sağ
 tarafına da bu öğelerin uzunluklarını bir çırpıda ekliyoruz.
-
-
-
-
-
-
-

--- a/source/sozlukler.rst
+++ b/source/sozlukler.rst
@@ -496,7 +496,7 @@ Sözlüklerin öteki veri tiplerinden önemli bir farkı, sözlük içinde yer
 alan öğelerin herhangi bir sıralama mantığına sahip olmamasıdır. Yani sözlükteki
 öğeler açısından 'sıra' diye bir kavram yoktur.
 
-.. note:: Python3.7'dan başlayarak sözlükler içerdikleri öğelerin eklenme sırasını korumaktadır. Python'un 3.7'den yüksek bir versiyonunda oluşturduğunuz sözlükleri ekrana yazdırmayı denerseniz sözlüğü oluştururken elemanların içinde bulunduğu sıranın korunduğunu siz de görebilirsiniz. Ancak sözlüklerin elemanlarına listeler gibi bir sıra ile (``liste[sıra]`` gibi) erişelemez. Ayrıntılı bilgi için `buraya <https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6>`_ bakabilirsiniz.
+.. note:: Python3.7'dan başlayarak sözlükler içerdikleri öğelerin eklenme sırasını korumaktadır. Python'un 3.7'den yüksek bir versiyonunda oluşturduğunuz sözlükleri ekrana yazdırmayı denerseniz sözlüğü oluştururken elemanların içinde bulunduğu sıranın korunduğunu siz de görebilirsiniz. Ancak sözlüklerin elemanlarına listeler gibi bir sıra ile (``liste[sıra]`` gibi) erişilemez. Ayrıntılı bilgi için `buraya <https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6>`_ bakabilirsiniz.
 
 Örneğin bir liste, demet veya karakter dizisi içindeki öğelere; bu öğelerin o
 liste, demet veya karakter dizisi içindeki sıralarına göre erişebilirsiniz::


### PR DESCRIPTION
Bölüm 14.04.02 ve Bölüm 32.03 #186
Adı altında acılan hataların incelenmesi ve giderilmesi

- donguler.rst altinda yer alan "Dosyaların İçeriğini Karşılaştırma basliginda" kod açıkklama hatası düzeltildi.
- sozlukler.rst dosyasında yer alan ve sözlüklerin sıraya sahip olması ile ilgili olan not, html dosyasında hatalı bir gorunume sahipti bu hata giderildi.
![Screenshot_29](https://github.com/yazbel/python-istihza/assets/66223190/5f33266d-5e8a-4062-9057-0a0a8241455a)
